### PR TITLE
Add cflinuxfs5 support for Nginx buildpack

### DIFF
--- a/jobs/nginx-buildpack/spec
+++ b/jobs/nginx-buildpack/spec
@@ -3,6 +3,7 @@ name: nginx-buildpack
 templates: {}
 
 packages:
+- nginx-buildpack-cflinuxfs5
 - nginx-buildpack-cflinuxfs4
 
 properties: {}

--- a/packages/nginx-buildpack-cflinuxfs5/packaging
+++ b/packages/nginx-buildpack-cflinuxfs5/packaging
@@ -1,0 +1,2 @@
+    set -e -x
+    cp nginx-buildpack/nginx?buildpack-*.zip ${BOSH_INSTALL_TARGET}

--- a/packages/nginx-buildpack-cflinuxfs5/spec
+++ b/packages/nginx-buildpack-cflinuxfs5/spec
@@ -1,0 +1,4 @@
+---
+name: nginx-buildpack-cflinuxfs5
+files:
+- nginx-buildpack/nginx?buildpack-cflinuxfs5-*.zip


### PR DESCRIPTION
This commit adds cflinuxfs5 (Ubuntu 24.04 noble) stack support to the nginx-buildpack BOSH release, following the same pattern used for cflinuxfs4.

Changes:
- Create packages/nginx-buildpack-cflinuxfs5/spec - package specification
- Create packages/nginx-buildpack-cflinuxfs5/packaging - build script
- Update jobs/nginx-buildpack/spec to reference cflinuxfs5 package

Both cflinuxfs4 and cflinuxfs5 packages will be included in future releases, enabling operators to deploy Nginx applications on either stack during the migration period from jammy (cflinuxfs4) to noble (cflinuxfs5).

The next BOSH release will include the cflinuxfs5 package, making it available for Cloud Foundry deployments.